### PR TITLE
Ignore files that did not match specified mask.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,11 +7,13 @@ const glob = require('glob');
 const defaults = require('./defaults');
 const utils = require('./utils');
 
-const getFilesByMask = (mask, options) => {
-    return q.nfcall(glob, mask, options)
+const isMask = (pattern) => glob.hasMagic(pattern);
+
+const getFilesByMask = (pattern, options) => {
+    return q.nfcall(glob, pattern, options)
         .then((paths) => {
-            return _.isEmpty(paths)
-                ? q.reject(new Error(`Cannot find files by mask ${mask}`))
+            return _.isEmpty(paths) && !isMask(pattern)
+                ? q.reject(new Error(`Cannot find files using path '${pattern}'`))
                 : paths;
         });
 };
@@ -35,7 +37,8 @@ const expandPath = (path, options) => {
 const processPaths = (paths, cb) => {
     return _(paths)
         .map(cb)
-        .thru(q.all).value()
+        .thru(q.all)
+        .value()
         .then(_.flatten)
         .then(_.uniq);
 };
@@ -49,6 +52,4 @@ exports.expandPaths = (paths, expandOpts, globOpts) => {
         .then((matchedPaths) => processPaths(matchedPaths, (path) => expandPath(path, expandOpts)));
 };
 
-exports.isMasks = (paths) => {
-    return [].concat(paths).every((path) => glob.hasMagic(path));
-};
+exports.isMasks = (patterns) => [].concat(patterns).every(isMask);

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,4 +52,4 @@ exports.expandPaths = (paths, expandOpts, globOpts) => {
         .then((matchedPaths) => processPaths(matchedPaths, (path) => expandPath(path, expandOpts)));
 };
 
-exports.isMasks = (patterns) => [].concat(patterns).every(isMask);
+exports.isMask = isMask;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,7 +48,7 @@ describe('path-utils', () => {
             return assert.isRejected(globExtra.expandPaths(['bad/mask']), 'Cannot find files by mask bad/mask');
         });
 
-        it('should ignore masks which contain magic symbols', () => {
+        it('should ignore masks which do not match to files', () => {
             glob.withArgs('bad/mask/*.js').yields(null, []);
             glob.withArgs('some/path/*.js').yields(null, ['some/path/file.js']);
 
@@ -234,13 +234,14 @@ describe('path-utils', () => {
         });
     });
 
-    describe('isMasks', () => {
-        it('should return true if all passed files are specified as masks', () => {
-            assert.isTrue(globExtra.isMasks(['some/path/*', 'another/**']));
+    describe('isMask', () => {
+        it('should return true if passed pattern specified as mask', () => {
+            assert.isOk(globExtra.isMask('some/path/*'));
+            assert.isOk(globExtra.isMask('another/**'));
         });
 
-        it('should return false if at least one of passed files is not a mask', () => {
-            assert.isFalse(globExtra.isMasks(['some/path/file.js', 'another/**']));
+        it('should return false if passed pattern is not a mask', () => {
+            assert.isNotOk(globExtra.isMask('some/path/file.js'));
         });
     });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,10 +38,26 @@ describe('path-utils', () => {
                 });
         });
 
-        it('should throw an error if a mask does not match files', () => {
-            glob.withArgs('bad/mask/*.js').yields(null, []);
+        it('should throw error for unexistent file path', () => {
+            glob.withArgs('bad/mask/file.js').yields(null, []);
+            return assert.isRejected(globExtra.expandPaths(['bad/mask/file.js']), 'Cannot find files by mask bad/mask/file.js');
+        });
 
-            return assert.isRejected(globExtra.expandPaths(['bad/mask/*.js']), /Cannot find files by mask bad\/mask\/\*\.js/);
+        it('should throw error for unexistent directory path', () => {
+            glob.withArgs('bad/mask').yields(null, []);
+            return assert.isRejected(globExtra.expandPaths(['bad/mask']), 'Cannot find files by mask bad/mask');
+        });
+
+        it('should ignore masks which contain magic symbols', () => {
+            glob.withArgs('bad/mask/*.js').yields(null, []);
+            glob.withArgs('some/path/*.js').yields(null, ['some/path/file.js']);
+
+            qfs.absolute.returnsArg(0);
+
+            return globExtra.expandPaths([
+                'bad/mask/*.js',
+                'some/path/*.js'
+            ]).then((absolutePaths) => assert.deepEqual(absolutePaths, ['some/path/file.js']));
         });
 
         it('should get absolute file path from passed mask according to formats option', () => {


### PR DESCRIPTION
Currently, if glob call did not  find any file for one of passed to expandPaths masks all execution will be failed. I think it should just ignore this behavior or just warn about this.